### PR TITLE
libpam: Update build instructions.

### DIFF
--- a/libpam/README
+++ b/libpam/README
@@ -1,7 +1,12 @@
 Example PAM module demonstrating two-factor authentication.
 
-Build and install by running "make install". If you don't have access to
-"sudo", you have to manually become "root" prior to calling "make install".
+Build & install by running:
+ * autoreconf -i
+ * ./configure
+ * make
+ * make install
+If you don't have access to "sudo", you have to manually become "root" prior
+to calling "make install".
 
 Then add this line to your PAM configuration file:
   auth required pam_google_authenticator.so


### PR DESCRIPTION
'make install' won't just work, for starters because there isn't a MakeFile generated?

make would be called by make install anyway, but I've left them separated so it's clearer only make install requires root.
